### PR TITLE
Use shared header and footer

### DIFF
--- a/Financier.html
+++ b/Financier.html
@@ -19,19 +19,7 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
-      <div class="header-content">
-        <div class="header-left" style="margin: 0;">
-          <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
-            <a href="index.html">Rhythm Desai</a>
-          </h1>
-        </div>
-        <nav class="header-nav" style="display: flex; gap: 2.5rem;">
-          <a href="Work.html">Work</a>
-          <a href="Resume.pdf" target="_blank">Resume</a>
-        </nav>
-      </div>
-    </header>
+        <div id="header-placeholder"></div>
     <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
       <div style="max-width: 60%;">
         <h1 style="font-size: 2rem; font-weight: 700;">Financier Project</h1>
@@ -219,11 +207,9 @@
         </div>
       </div>
     </div>
-    <footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
-      <nav><a href="https://github.com/RhythmD22" target="_blank"><i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span></a><span>/</span> <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank"><i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span></a><span>/</span> <a href="mailto:rhythmdesai22@gmail.com"><i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span></a></nav>
-      <p>© 2024 Rhythm Desai</p>
-    </footer>
+        <div id="footer-placeholder"></div>
   </div>
+  <script src="templates.js"></script>
   <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>

--- a/SmartShuttle.html
+++ b/SmartShuttle.html
@@ -19,19 +19,7 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
-      <div class="header-content">
-        <div class="header-left" style="margin: 0;">
-          <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
-            <a href="index.html">Rhythm Desai</a>
-          </h1>
-        </div>
-        <nav class="header-nav" style="display: flex; gap: 2.5rem;">
-          <a href="Work.html">Work</a>
-          <a href="Resume.pdf" target="_blank">Resume</a>
-        </nav>
-      </div>
-    </header>
+        <div id="header-placeholder"></div>
     <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
       <div style="max-width: 60%;">
         <h1 style="font-size: 2rem; font-weight: 700;">SmartShuttle Project</h1>
@@ -110,11 +98,9 @@
       allowfullscreen>
     </iframe>
   </main>
-    <footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
-      <nav><a href="https://github.com/RhythmD22" target="_blank"><i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span></a><span>/</span> <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank"><i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span></a><span>/</span> <a href="mailto:rhythmdesai22@gmail.com"><i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span></a></nav>
-      <p>© 2024 Rhythm Desai</p>
-    </footer>
+        <div id="footer-placeholder"></div>
   </div>
+  <script src="templates.js"></script>
   <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>

--- a/Twine.html
+++ b/Twine.html
@@ -23,19 +23,7 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
-      <div class="header-content">
-        <div class="header-left" style="margin: 0;">
-          <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
-            <a href="index.html">Rhythm Desai</a>
-          </h1>
-        </div>
-        <nav class="header-nav" style="display: flex; gap: 2.5rem;">
-          <a href="Work.html">Work</a>
-          <a href="Resume.pdf" target="_blank">Resume</a>
-        </nav>
-      </div>
-    </header>
+        <div id="header-placeholder"></div>
     <main class="main-content" style="display: block; padding: 2rem; height: auto;">
       <!-- Left Column -->
       <div style="width: 100%; margin-bottom: 4rem;">
@@ -91,11 +79,9 @@
         </div>
       </div>
     </main>
-    <footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
-      <nav><a href="https://github.com/RhythmD22" target="_blank"><i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span></a><span>/</span> <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank"><i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span></a><span>/</span> <a href="mailto:rhythmdesai22@gmail.com"><i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span></a></nav>
-      <p>© 2024 Rhythm Desai</p>
-    </footer>
+        <div id="footer-placeholder"></div>
   </div>
+  <script src="templates.js"></script>
   <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>

--- a/Work.html
+++ b/Work.html
@@ -262,19 +262,7 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
-      <div class="header-content">
-        <div class="header-left" style="margin: 0;">
-          <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
-            <a href="index.html">Rhythm Desai</a>
-          </h1>
-        </div>
-        <nav class="header-nav" style="display: flex; gap: 2.5rem;">
-          <a href="Work.html">Work</a>
-          <a href="Resume.pdf" target="_blank">Resume</a>
-        </nav>
-      </div>
-    </header>
+        <div id="header-placeholder"></div>
 
     <main class="main-content">
       <section class="work-summary">
@@ -380,11 +368,9 @@
           </div>
         </section>
       </div>
-    <footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
-      <nav><a href="https://github.com/RhythmD22" target="_blank"><i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span></a><span>/</span> <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank"><i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span></a><span>/</span> <a href="mailto:rhythmdesai22@gmail.com"><i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span></a></nav>
-      <p>© 2024 Rhythm Desai</p>
-    </footer>
+        <div id="footer-placeholder"></div>
   </div>
+  <script src="templates.js"></script>
   <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,16 @@
+<footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
+  <nav>
+    <a href="https://github.com/RhythmD22" target="_blank">
+      <i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span>
+    </a>
+    <span>/</span>
+    <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank">
+      <i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span>
+    </a>
+    <span>/</span>
+    <a href="mailto:rhythmdesai22@gmail.com">
+      <i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span>
+    </a>
+  </nav>
+  <p>© 2024 Rhythm Desai</p>
+</footer>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,13 @@
+<header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
+  <div class="header-content">
+    <div class="header-left" style="margin: 0;">
+      <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
+        <a href="index.html">Rhythm Desai</a>
+      </h1>
+    </div>
+    <nav class="header-nav" style="display: flex; gap: 2.5rem;">
+      <a href="Work.html">Work</a>
+      <a href="Resume.pdf" target="_blank">Resume</a>
+    </nav>
+  </div>
+</header>

--- a/index.html
+++ b/index.html
@@ -41,19 +41,7 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
-      <div class="header-content">
-        <div class="header-left" style="margin: 0;">
-          <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
-            <a href="index.html">Rhythm Desai</a>
-          </h1>
-        </div>
-        <nav class="header-nav" style="display: flex; gap: 2.5rem;">
-          <a href="Work.html">Work</a>
-          <a href="Resume.pdf" target="_blank">Resume</a>
-        </nav>
-      </div>
-    </header>
+        <div id="header-placeholder"></div>
     <div class="description-container" style="flex: 1; padding-top: 15vh;">
       <section class="intro">
         <div class="intro-text" style="background-color: #faefd8; padding: 2rem; margin: 4rem 2rem 0 6rem; max-width: 480px; border-radius: 4px; font-weight: 300;">
@@ -64,22 +52,8 @@
         <img src="Images/Profile.png" alt="Profile image" class="profile-image">
       </section>
     </div>
-    <footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
-      <nav>
-        <a href="https://github.com/RhythmD22" target="_blank">
-          <i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span>
-        </a>
-        <span>/</span>
-        <a href="https://www.linkedin.com/in/rhythm-desai" target="_blank">
-          <i class="fab fa-linkedin" aria-hidden="true"></i><span class="link-text">LinkedIn</span>
-        </a>
-        <span>/</span>
-        <a href="mailto:rhythmdesai22@gmail.com">
-          <i class="fas fa-envelope" aria-hidden="true"></i><span class="link-text">Email</span>
-        </a>
-      </nav>
-      <p>© 2024 Rhythm Desai</p>
-    </footer>
+        <div id="footer-placeholder"></div>
   </div>
+  <script src="templates.js"></script>
 </body>
 </html>

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const load = (id, file) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    fetch(file)
+      .then(resp => resp.text())
+      .then(html => { el.innerHTML = html; });
+  };
+  load('header-placeholder', 'header.html');
+  load('footer-placeholder', 'footer.html');
+});


### PR DESCRIPTION
## Summary
- create reusable `header.html` and `footer.html`
- load common markup with `templates.js`
- replace inline header/footer markup on all pages with placeholders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2e24329c8320b0a4d9fad83223e1