### PR TITLE
Refactor repeated inline styles

### DIFF
--- a/Financier.html
+++ b/Financier.html
@@ -20,33 +20,33 @@
 <body>
   <div class="container">
         <div id="header-placeholder"></div>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
+    <main class="main-content center-flex" style="gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
       <div style="max-width: 60%;">
-        <h1 style="font-size: 2rem; font-weight: 700;">Financier Project</h1>
+        <h1 class="page-title">Financier Project</h1>
         <p style="font-size: 1.15rem;">The Financier budgeting app was designed to help college students manage expenses, set goals, and track income with tailored features based on user research. It includes goal setting, transaction tracking, analytics, a built-in calculator, and categorized money-saving tips—all built with a responsive and intuitive UI.</p>
       </div>
-      <div style="font-size: 0.9rem; text-align: left; line-height: 1.8;">
+        <div class="info-meta">
         <p><strong>CLIENT</strong><br>Independent Study with Dr. Dmitriy Babichenko</p>
         <p><strong>MY ROLE</strong><br>UI/UX Designer & Developer</p>
         <p><strong>TEAM</strong><br>Individual Contribution</p>
         <p><strong>TIMELINE</strong><br>Spring semester 2025</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem;">
+    <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem;">
       <div style="max-width: 60%;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Problem Statement</h1>
+        <h1 class="section-title">Problem Statement</h1>
       </div>
       <div style="font-size: 1.15rem;">
         <p>College students often face the challenge of budgeting without a steady income, especially during the school year. Many budgeting apps assume regular income streams, making it difficult for students who rely on savings or sporadic transfers. A common desire is a simple, low-cost tool that tracks spending while accommodating student-specific needs like meal planning and flexible financial goals. Without tools that reflect their unique situations, students struggle to stay on budget and miss out on opportunities like goal-based saving.</p>
       </div>
       <div style="margin: 2rem 0 2rem;">
-        <img loading="lazy" src="Images/iGrad.png" alt="iGrad Budgeting Tool Screenshot" style="width: 100%; height: auto; border: 1px solid #ccc;" />
-        <p style="font-size: 0.85rem; color: #555; text-align: center; margin: 0.5rem 0 1rem;">iGrad: Budget Tool</p>
+        <img loading="lazy" src="Images/iGrad.png" alt="iGrad Budgeting Tool Screenshot" class="full-image" style="border: 1px solid #ccc;" />
+        <p class="caption">iGrad: Budget Tool</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-bottom: 6rem;">
+    <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-bottom: 6rem;">
       <div style="max-width: 60%;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Role & Responsibilities</h1>
+        <h1 class="section-title">Role & Responsibilities</h1>
       </div>
       <div style="font-size: 1.15rem;">
         <p>This was a solo project completed as part of an independent study capstone. I conducted all user research, designed the interface in Figma, and developed the web application using HTML, CSS, and JavaScript. Responsibilities included designing and executing interviews, analyzing student budgeting needs, designing and prototyping a mockup, and building a responsive and fully functional web app from the ground up.</p>
@@ -54,29 +54,29 @@
     </main>
     <div style="display: flex; justify-content: center; align-items: flex-start; gap: 2rem; margin: 2rem auto; max-width: 1200px;">
       <div style="width: 33%;">
-        <img loading="lazy" src="Images/Outline 1.png" alt="Outline Page 1" style="width: 100%; height: auto;" />
-        <p style="font-size: 0.85rem; color: #555; text-align: center; margin: 0.5rem 0 1rem;">Outline Page 1: Project Description, Learning Objectives, Learning Outcomes</p>
+        <img loading="lazy" src="Images/Outline 1.png" alt="Outline Page 1" class="full-image" />
+        <p class="caption">Outline Page 1: Project Description, Learning Objectives, Learning Outcomes</p>
       </div>
       <div style="width: 33%;">
-        <img loading="lazy" src="Images/Outline 2.png" alt="Outline Page 2" style="width: 100%; height: auto;" />
-        <p style="font-size: 0.85rem; color: #555; text-align: center; margin: 0.5rem 0 1rem;">Outline Page 2: Learning Outcomes cont., Deliverables</p>
+        <img loading="lazy" src="Images/Outline 2.png" alt="Outline Page 2" class="full-image" />
+        <p class="caption">Outline Page 2: Learning Outcomes cont., Deliverables</p>
       </div>
       <div style="width: 33%;">
-        <img loading="lazy" src="Images/Outline 3.png" alt="Outline Page 3" style="width: 100%; height: auto;" />
-        <p style="font-size: 0.85rem; color: #555; text-align: center; margin: 0.5rem 0 1rem;">Outline Page 3: Deliverables Timeline, Research Plan</p>
+        <img loading="lazy" src="Images/Outline 3.png" alt="Outline Page 3" class="full-image" />
+        <p class="caption">Outline Page 3: Deliverables Timeline, Research Plan</p>
       </div>
     </div>
     <div style="background: #ffffff; padding: 2rem; box-shadow: 0 0 8px rgba(0, 0, 0, 0.1); border-radius: 8px; margin: 8rem auto 2rem; max-width: 1200px;">
       <main class="main-content" style="display: flex; justify-content: center; align-items: flex-start; gap: 5rem; padding: 2rem; margin-top: 4rem;">
         <div style="max-width: 60%;">
-          <h1 style="font-size: 1.8rem; font-weight: 700;">Research Plan</h1>
+          <h1 class="section-title">Research Plan</h1>
           <ul style="font-size: 1.15rem; line-height: 1.8;">
             <li>Interviewed 10 college students to gather insights on budgeting habits.</li>
             <li>Extracted themes such as spending priorities, income sources, and financial confidence.</li>
             <li>Used findings to guide features like expense tracking, meal budgeting, and savings goals.</li>
           </ul>
           <div style="width: 100%;">
-            <h1 style="font-size: 1.8rem; font-weight: 700;">Participant Information</h1>
+            <h1 class="section-title">Participant Information</h1>
             <ul style="font-size: 1.15rem; line-height: 1.8;">
               <li><strong>Total Participants:</strong> 10</li>
               <li><strong>Age Range:</strong> 20–22 years old</li>
@@ -87,7 +87,7 @@
           <p style="font-size: 1.15rem; margin-top: 1rem;"><strong>General Focus:</strong> Identifying key student expenses, how meal plans and job status shape budgeting, and common discretionary spending patterns.</p>
         </div>
         <div style="font-size: 1.15rem;">
-          <h1 style="font-size: 1.8rem; font-weight: 700;">Interview Questions</h1>
+          <h1 class="section-title">Interview Questions</h1>
           <ol style="line-height: 1.8;">
             <li>How do you typically allocate your money each month?</li>
             <li>What are your most common expenses as a college student?</li>
@@ -104,7 +104,7 @@
         </div>
       </main>
     <div style="margin-top: 4rem;">
-      <h1 style="font-size: 1.8rem; font-weight: 700;">Key Interview Findings</h1>
+      <h1 class="section-title">Key Interview Findings</h1>
       <ul style="font-size: 1.15rem; line-height: 1.8; padding-left: 1.2rem;">
         <li>Students with meal plans mostly spend on snacks, drinks, and entertainment, while those without must budget more carefully for groceries and meals.</li>
         <li>Video games, dining out, and social outings are common discretionary expenses, especially among students living on campus.</li>
@@ -117,7 +117,7 @@
     </div>
     <p style="font-size: 0.9rem; color: #555; text-align: center; margin: 0rem 0 2rem;">User Research Overview – Spring 2025</p>
     
-    <h1 style="text-align: center; font-size: 1.8rem; font-weight: 700; margin: 6rem auto 2rem; max-width: 1200px;">Design Process</h1>
+    <h1 class="section-title" style="text-align: center; margin: 6rem auto 2rem; max-width: 1200px;">Design Process</h1>
     <!-- Outlines and mockup moved below white card -->
     <div style="display: flex; justify-content: center; align-items: flex-start; gap: 2rem; margin: 4rem auto 0; max-width: 1200px; position: relative;">
       <div style="width: 40%; display: flex; flex-direction: column; align-items: center;">
@@ -160,13 +160,13 @@
       </div>
       <div style="width: 60%;">
         <div style="margin-bottom: 2rem;">
-          <img loading="lazy" src="Images/Financier mockup.png" alt="Financier App Mockup" style="width: 100%; height: auto;" />
-          <p style="font-size: 0.85rem; color: #555; text-align: center; margin: 0.5rem 0 1rem;">Financier: Interactive Budgeting App Mockup in Figma</p>
+          <img loading="lazy" src="Images/Financier mockup.png" alt="Financier App Mockup" class="full-image" />
+          <p class="caption">Financier: Interactive Budgeting App Mockup in Figma</p>
         </div>
       </div>
     </div>
     <div style="margin: 0 auto; width: 100%; max-width: 1200px;">
-      <h1 style="font-size: 1.8rem; font-weight: 700; text-align: left;">Figma Prototype</h1>
+      <h1 class="section-title" style="text-align: left;">Figma Prototype</h1>
     </div>
     <div style="margin-top: 0rem; width: 100%; max-width: 1200px; margin-left: auto; margin-right: auto;">
       <iframe loading="lazy"
@@ -181,9 +181,9 @@
       </p>
     </div>
     <div style="margin: 6rem auto 2rem; width: 100%; max-width: 1200px;">
-      <h1 style="font-size: 1.8rem; font-weight: 700; text-align: left;">Live Website</h1>
+      <h1 class="section-title" style="text-align: left;">Live Website</h1>
       <a href="https://rhythmd22.github.io/Financier/" target="_blank">
-        <img loading="lazy" src="Images/Financier site.png" alt="Financier App Screenshot" style="width: 100%; height: auto; border-radius: 8px; border: 1px solid rgba(0,0,0,0.1);" />
+        <img loading="lazy" src="Images/Financier site.png" alt="Financier App Screenshot" class="screenshot-img" />
       </a>
       <div style="background: #ffffff; padding: 2rem; margin: 3rem auto 0; width: 100%; max-width: 1135px; box-shadow: 0 0 8px rgba(0, 0, 0, 0.05); border-radius: 8px;">
         <div style="margin-top: 0;">
@@ -210,7 +210,7 @@
         <div id="footer-placeholder"></div>
   </div>
   <script src="templates.js"></script>
-  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
+  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" class="scroll-top-btn">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>
     </svg>

--- a/SmartShuttle.html
+++ b/SmartShuttle.html
@@ -20,71 +20,71 @@
 <body>
   <div class="container">
         <div id="header-placeholder"></div>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
+    <main class="main-content center-flex" style="gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px);">
       <div style="max-width: 60%;">
-        <h1 style="font-size: 2rem; font-weight: 700;">SmartShuttle Project</h1>
+        <h1 class="page-title">SmartShuttle Project</h1>
         <p style="font-size: 1.15rem;">The SmartShuttle Tracking App addresses inefficiencies in the University of Pittsburgh’s campus shuttle service, focusing on inconsistent arrival times, overcrowding, and unreliable updates. It provides real-time GPS tracking, estimated arrival times, occupancy details, and more, enabling students and staff to plan their commutes more efficiently.</p>
       </div>
-      <div style="font-size: 0.9rem; text-align: left; line-height: 1.8;">
+        <div class="info-meta">
         <p><strong>CLIENT</strong><br>INFSCI 0410 - Human Centered Systems</p>
         <p><strong>MY ROLE</strong><br>UI/UX Designer</p>
         <p><strong>TEAM</strong><br>Individual Contribution</p>
         <p><strong>TIMELINE</strong><br>3 weeks in Fall 2024</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
       <div style="max-width: 60%;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Inspiration</h1>
+        <h1 class="section-title">Inspiration</h1>
       </div>
       <div style="font-size: 1.15rem;">
         <p>The SmartShuttle concept began as a response to persistent issues with Pitt’s campus shuttles. Riders frequently face late or crowded buses without reliable arrival updates, making each trip uncertain. Combining GPS tracking with live occupancy data provides students and staff clear information on when and where shuttles arrive. SmartShuttle uses existing mobile and location technology to make planning a campus commute simple and stress-free.</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Phase 1</h1>
+        <h1 class="section-title">Phase 1</h1>
       </div>
       <div style="display: flex; gap: 6rem; align-items: flex-end;">
         <img src="Images/Phase 1.png" alt="Phase 1 diagram" style="max-width: 33.333%; height: auto;">
         <img src="Images/Phase 1-2.png" alt="Phase 1-2 diagram" style="max-width: 33.333%; height: auto;">
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
         <p>Phase 1 focuses on user research and requirements gathering. Interviews with students and staff revealed challenges such as shuttle unreliability, overcrowding, and parking difficulties. These findings informed the initial design of SmartShuttle’s real-time tracking, occupancy data, and route optimization features to address key user pain points.</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Phase 2</h1>
+        <h1 class="section-title">Phase 2</h1>
       </div>
       <div style="display: flex; gap: 6rem; align-items: flex-end;">
         <img src="Images/Phase 2.png" alt="Phase 2 diagram" style="max-width: 33.333%; height: auto;">
         <img src="Images/Phase 2-2.png" alt="Phase 2-2 diagram" style="max-width: 33.333%; height: auto;">
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
         <p>Phase 2 encompasses finalizing SmartShuttle’s key features and planning for deployment. Features include real-time GPS tracking of shuttles, push notifications for delays and arrival times, occupancy displays to help users plan, and a feedback mechanism for reporting issues. Implementation strategies involve collaborating with the University’s transportation department to install IoT sensors and GPS trackers, developing native mobile apps for iOS and Android, piloting on high-demand routes, and collecting user feedback to refine the system. This phase ensures a scalable, cost-effective rollout that addresses shuttle inefficiencies while laying the foundation for future enhancements.</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
+      <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Phase 3</h1>
+        <h1 class="section-title">Phase 3</h1>
       </div>
       <div style="display: flex; gap: 6rem; align-items: flex-end;">
         <img src="Images/Phase 3.png" alt="Phase 3 diagram" style="max-width: 33.333%; height: auto;">
         <img src="Images/Phase 3-2.png" alt="Phase 3-2 diagram" style="max-width: 33.333%; height: auto;">
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
+    <main class="main-content center-flex" style="padding: 2rem; margin-top: -8rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
         <p>Phase 3 focuses on final refinement, interface design, and ethical considerations. The app includes a Welcome screen for onboarding, Live Tracking map, Live Notifications area, a Settings page, and a User Feedback form ensuring anonymity. User feedback will be collected through in-app forms and surveys to drive iterative improvements. Ethical considerations such as privacy (minimal data collection, anonymized GPS), inclusivity (accessibility for users with disabilities), and fairness (unbiased notifications and shuttle details) ensure the app serves all users responsibly.</p>
       </div>
     </main>
-    <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
+    <main class="main-content center-flex" style="gap: 6rem; padding: 2rem; margin-top: 4rem; margin-bottom: 6rem;">
       <div style="max-width: 60%; text-align: center;">
-        <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0;">Final Design</h1>
+        <h1 class="section-title">Final Design</h1>
       </div>
       <div style="font-size: 1.15rem;">
         <p>The final SmartShuttle interface emphasizes clarity and ease of use. A real-time map displays shuttle locations and occupancy levels, while a clean, icon-based navigation lets users quickly switch between live tracking, notifications, settings, and feedback. High-contrast colors improve readability, and responsive layouts ensure a seamless experience. Every screen balances functionality with minimal visual clutter, making it simple for riders to find shuttle times, view capacity, and send feedback without distraction.</p>
@@ -101,7 +101,7 @@
         <div id="footer-placeholder"></div>
   </div>
   <script src="templates.js"></script>
-  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
+  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" class="scroll-top-btn">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>
     </svg>

--- a/Twine.html
+++ b/Twine.html
@@ -27,12 +27,12 @@
     <main class="main-content" style="display: block; padding: 2rem; height: auto;">
       <!-- Left Column -->
       <div style="width: 100%; margin-bottom: 4rem;">
-        <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px); margin-bottom: 4rem;">
+          <main class="main-content center-flex" style="gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px); margin-bottom: 4rem;">
           <div style="max-width: 60%;">
-            <h1 style="font-size: 2rem; font-weight: 700;">The Guardian's Legacy</h1>
+              <h1 class="page-title">The Guardian's Legacy</h1>
             <p style="font-size: 1.15rem;">A choice-driven interactive fantasy that follows a young hero from a quiet village into an enchanted forest to recover a powerful relic known as the Luminous Artifact. The story adapts based on player decisions, offering unique experiences through weapon choices, moral dilemmas, and dynamic encounters with both allies and adversaries, including a sorcerer and a mysterious Guardian.</p>
           </div>
-          <div style="font-size: 0.9rem; text-align: left; line-height: 1.8;">
+            <div class="info-meta">
             <p><strong>CLIENT</strong><br>ENGCMP 0610 - Composing Digital Media</p>
             <p><strong>MY ROLE</strong><br>Writer, Designer, and Programmer</p>
             <p><strong>TEAM</strong><br>Individual Contribution</p>
@@ -40,18 +40,18 @@
           </div>
         </main>
         <a href="Twine/The Guardian's Legacy.html" target="_blank" style="display: block; margin-top: 6rem; padding: 0rem 2rem 2rem 2rem; width: 100%;">
-          <img loading="lazy" src="Images/The Guardian's Legacy.png" alt="The Guardian's Legacy" style="width: 100%; height: auto; border-radius: 8px; border: 1px solid rgba(0,0,0,0.1);" />
+          <img loading="lazy" src="Images/The Guardian's Legacy.png" alt="The Guardian's Legacy" class="screenshot-img" />
         </a>
       </div>
 
       <!-- Right Column -->
       <div style="width: 100%; margin-bottom: 4rem;">
-        <main class="main-content" style="display: flex; justify-content: center; align-items: center; gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px); margin-bottom: 4rem;">
+          <main class="main-content center-flex" style="gap: 2rem; padding: 2rem; min-height: calc(100vh - 160px); margin-bottom: 4rem;">
           <div style="max-width: 60%;">
-            <h1 style="font-size: 2rem; font-weight: 700;">Archibald and the Steel Monolith</h1>
+              <h1 class="page-title">Archibald and the Steel Monolith</h1>
             <p style="font-size: 1.15rem;">A Twine game blending fantasy and sci-fi, following a knight flung into a corporate-dystopian future where his moral compass is tested across different timelines. Built with branching paths, dynamic outcomes, and a climactic minigame, the story adapts to player-defined values like duty, honor, and adaptability.</p>
           </div>
-          <div style="font-size: 0.9rem; text-align: left; line-height: 1.8;">
+            <div class="info-meta">
             <p><strong>CLIENT</strong><br>ENGLIT 0702 - Introduction to Game Studies</p>
             <p><strong>MY ROLE</strong><br>Co-Writer, Designer, and Programmer</p>
             <p><strong>TEAM</strong><br>Collaborative team project with David Halasz</p>
@@ -59,7 +59,7 @@
           </div>
         </main>
         <a href="Twine/Archibald and the Steel Monolith.html" target="_blank" style="display: block; margin-top: 4rem; padding: 0rem 2rem 2rem 2rem; width: 100%;">
-          <img loading="lazy" src="Images/Archibald and the Steel Monolith.png" alt="Archibald and the Steel Monolith" style="width: 100%; height: auto; border-radius: 8px; border: 1px solid rgba(0,0,0,0.1);" />
+            <img loading="lazy" src="Images/Archibald and the Steel Monolith.png" alt="Archibald and the Steel Monolith" class="screenshot-img" />
         </a>
         <div style="text-align: center; margin-top: 4rem;">
           <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Insights from My Teammate</h2>
@@ -82,7 +82,7 @@
         <div id="footer-placeholder"></div>
   </div>
   <script src="templates.js"></script>
-  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" style="position: fixed; bottom: 1.5rem; right: 1.5rem; background: none; border: none; cursor: pointer; z-index: 1000;">
+  <button onclick="window.scrollTo({top: 0, behavior: 'smooth'});" class="scroll-top-btn">
     <svg width="96" height="72" viewBox="0 0 24 24" fill="none" stroke="#df3f41" stroke-width="0.6" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="18 15 12 9 6 15"></polyline>
     </svg>

--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,4 @@
-<footer class="site-footer" style="width: 100%; margin-top: auto; text-align: center; padding: 2rem 0 1rem;">
+<footer class="site-footer">
   <nav>
     <a href="https://github.com/RhythmD22" target="_blank">
       <i class="fab fa-github" aria-hidden="true"></i><span class="link-text">GitHub</span>

--- a/header.html
+++ b/header.html
@@ -1,11 +1,11 @@
-<header class="site-header" style="position: relative; padding: 1.5rem 0 0;">
+<header class="site-header">
   <div class="header-content">
-    <div class="header-left" style="margin: 0;">
-      <h1 class="header-name fw-medium" style="font-size: 1.4rem; margin: 0; letter-spacing: 0em;">
+  <div class="header-left">
+      <h1 class="header-name fw-medium">
         <a href="index.html">Rhythm Desai</a>
       </h1>
     </div>
-    <nav class="header-nav" style="display: flex; gap: 2.5rem;">
+    <nav class="header-nav">
       <a href="Work.html">Work</a>
       <a href="Resume.pdf" target="_blank">Resume</a>
     </nav>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,9 @@
 <body>
   <div class="container">
         <div id="header-placeholder"></div>
-    <div class="description-container" style="flex: 1; padding-top: 15vh;">
+    <div class="description-container">
       <section class="intro">
-        <div class="intro-text" style="background-color: #faefd8; padding: 2rem; margin: 4rem 2rem 0 6rem; max-width: 480px; border-radius: 4px; font-weight: 300;">
+        <div class="intro-text">
             <h2 style="font-size: 2rem; margin: 0 0 1rem; font-weight: 600;">Hey, I'm Rhythm!</h2>
           <p style="line-height: 1.5;">I'm a recent University of Pittsburgh graduate and an aspiring UI/UX Designer. I design clean interfaces and immersive experiences that bring together form and function.</p>
           <p style="line-height: 1.5;">I combine design tools and frontend development to craft meaningful, intuitive digital products.</p>

--- a/styles.css
+++ b/styles.css
@@ -166,3 +166,56 @@ body {
 .fw-medium   { font-weight: 500; }
 .fw-semibold { font-weight: 600; }
 .fw-bold     { font-weight: 700; }
+
+/* Utility classes extracted from repeated inline styles */
+.center-flex {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.scroll-top-btn {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.section-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.page-title {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.info-meta {
+  font-size: 0.9rem;
+  text-align: left;
+  line-height: 1.8;
+}
+
+.caption {
+  font-size: 0.85rem;
+  color: #555;
+  text-align: center;
+  margin: 0.5rem 0 1rem;
+}
+
+.full-image {
+  width: 100%;
+  height: auto;
+}
+
+.screenshot-img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- remove redundant inline styles from header and footer templates
- add utility classes for common inline styles in `styles.css`
- apply these classes across pages to replace inline styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3da197e88320bd9f87b032204533